### PR TITLE
adding component and flexbox layout directives

### DIFF
--- a/lib/directives/ComponentDirective.js
+++ b/lib/directives/ComponentDirective.js
@@ -1,7 +1,7 @@
 const convertPxStyle = value => typeof value === 'undefined' ? '' : value.toString().includes('%') ? value : value + 'px';
 
 const ComponentDirective = {
-    bind(el, vnode) {
+    bind(el, binding, vnode) {
         const { context } = vnode;
         const { $attrs } = context;
         el.style.width = convertPxStyle($attrs.width);

--- a/lib/directives/ComponentDirective.js
+++ b/lib/directives/ComponentDirective.js
@@ -1,0 +1,13 @@
+const convertPxStyle = value => typeof value === 'undefined' ? '' : value.toString().includes('%') ? value : value + 'px';
+
+const ComponentDirective = {
+    bind(el, vnode) {
+        const { context } = vnode;
+        const { $attrs } = context;
+        el.style.width = convertPxStyle($attrs.width);
+        el.style.height = convertPxStyle($attrs.height);
+        el.style.backgroundColor = $attrs.backgroundColor;
+    }
+};
+
+export default ComponentDirective;

--- a/lib/directives/FlexboxLayoutDirective.js
+++ b/lib/directives/FlexboxLayoutDirective.js
@@ -1,5 +1,5 @@
 const FlexboxLayoutDirective = {
-    bind(el, vnode) {
+    bind(el, binding, vnode) {
         const { context } = vnode;
         const { $attrs } = context;
         el.style.order = $attrs.order;

--- a/lib/directives/FlexboxLayoutDirective.js
+++ b/lib/directives/FlexboxLayoutDirective.js
@@ -1,0 +1,11 @@
+const FlexboxLayoutDirective = {
+    bind(el, vnode) {
+        const { context } = vnode;
+        const { $attrs } = context;
+        el.style.order = $attrs.order;
+        el.style.flexGrow = $attrs.flexGrow;
+        el.style.flexShrink = $attrs.flexShrink;
+    }
+};
+
+export default FlexboxLayoutDirective;


### PR DESCRIPTION
Component directive supports only three properties which are width, height and background color for now. FlexboxLayout directive provides the additional props which are described in the docs for children.

Reference:
https://nativescript-vue.org/en/docs/elements/layouts/flexbox-layout/#additional-children-props