### PR TITLE
ScrollView > tests, v-common-directive added, styles fixed.

### DIFF
--- a/src/components/ScrollView.vue
+++ b/src/components/ScrollView.vue
@@ -1,43 +1,40 @@
 <template>
-    <div @scroll="onScroll($event)" :class="scrollViewClass" :style="{ width: widthStyle, height: heightStyle}">
+    <div v-common-directive @scroll="onScroll($event)" :class="scrollViewClass">
         <slot></slot>
     </div>
 </template>
 
 <script>
-import { debounce, camelCaseToDash, addPx } from '../helpers/helpers';
+import { debounce, camelCaseToDash } from '../helpers/helpers';
+import CommonDirective from '../directives/CommonDirective';
 
 export default {
   name: 'ScrollView',
   props: {
     orientation: {
       type: String,
-      default: 'horizontal',
+      default: 'vertical',
       validator: value => ['horizontal', 'vertical'].indexOf(value) !== -1,
     },
     scrollBarIndicatorVisible: {
       type: Boolean,
       default: true,
     },
-    width: [Number, String],
-    height: [Number, String],
   },
   computed: {
-    widthStyle: function() {
-      return addPx(this.width);
-    },
-    heightStyle: function() {
-      return addPx(this.height);
-    },
     scrollViewClass: function() {
-      return `nvw-scrollview nvw-scrollview${this.orientation !== 'none' ? '--' + camelCaseToDash(this.orientation) : ''}
-      ${this.scrollBarIndicatorVisible ? '' : '--hide'}`;
+      return `nvw-scrollview nvw-scrollview${this.orientation !== 'none' ? '--' + camelCaseToDash(this.orientation) : ''}${
+        this.scrollBarIndicatorVisible ? '' : '--hide'
+      }`;
     },
   },
   methods: {
-    onScroll: debounce(function() {
+    onScroll: debounce(function(event) {
       this.$emit('scroll', event);
     }, 100),
+  },
+  directives: {
+    'common-directive': CommonDirective,
   },
 };
 </script>
@@ -45,14 +42,21 @@ export default {
 <style lang="scss" scoped>
 .nvw-scrollview {
   &--horizontal {
-    overflow: auto;
-    white-space: nowrap;
-  }
-  &--vertical {
-    overflow-y: scroll;
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    // Child elements width must be same as parent width.
+    * {
+      white-space: nowrap !important;
+    }
   }
 
-  //TODO Web browsers not supported hidden scrollbar. If overflow set to hidden, scroll on disable. The solution will be found.
+  &--vertical {
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  //TODO Web browsers not supported hidden scrollbar. If overflow set to hidden, scrolling will disable.
   &--horizontal,
   &--vertical {
     &--hide {

--- a/tests/unit/components/ScrollView.spec.js
+++ b/tests/unit/components/ScrollView.spec.js
@@ -1,0 +1,75 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { mount } from '@vue/test-utils';
+import { ScrollView, Label } from '../../../src/main';
+
+describe('ScrollView', () => {
+  // Mock up values.
+  const orientation = 'horizontal';
+  const scrollBarIndicatorVisible = true;
+
+  const Label1 = {
+    render(h) {
+      return h(Label, {
+        props: {
+          text:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed convallis, libero ut vehicula hendrerit, urna massa porta nulla, ' +
+            'id condimentum nulla elit sodales lacus. Nulla fringilla pulvinar viverra. Nam pulvinar aliquam risus ut molestie. Interdum et' +
+            ' malesuada fames ac ante ipsum primis in faucibus. Sed faucibus pharetra diam, eget feugiat velit porttitor vitae. In vulputate' +
+            ' maximus ligula, vel venenatis orci tempus a. Vestibulum in quam eget lectus bibendum condimentum. Vestibulum eleifend aliquet ' +
+            'quam in interdum. Nulla facilisi.',
+        },
+      });
+    },
+  };
+
+  const wrapper = mount(ScrollView, {
+    propsData: {
+      orientation,
+      scrollBarIndicatorVisible,
+    },
+    attrs: {
+      width: '50',
+      height: '30',
+    },
+    slots: {
+      default: [Label1],
+    },
+  });
+
+  describe('the component received given props correctly.', () => {
+    it(`Given value property is equal to ${orientation}.`, () => {
+      expect(wrapper.props().orientation).to.equal(orientation);
+    });
+    it(`Given maxValue property is equal to ${scrollBarIndicatorVisible}.`, () => {
+      expect(wrapper.props().scrollBarIndicatorVisible).to.equal(scrollBarIndicatorVisible);
+    });
+  });
+
+  //TODO scroll event not working. It will be check again.
+  //TODO ScrollView:orientation=horizontal>StackLayout:orientation=vertical>Label:textWrap=true will be check. It's different result with Native Vue Playground.
+  xdescribe('Listen to events', () => {
+    it('Scroll event check', () => {
+      const onScrollEvent = sinon.spy(ScrollView.methods, 'onScroll');
+      const scrollWrapper = wrapper.findAll('div').at(0).element;
+
+      scrollWrapper.scrollLeft = 100;
+      scrollWrapper.scrollTop = 100;
+
+      expect(wrapper.emitted().onScroll.length).to.equal(1);
+      expect(onScrollEvent.called).to.equal(true);
+    });
+  });
+
+  describe('the component receives given props correctly.', () => {
+    it(`Orientation property is equal to horizontal`, () => {
+      expect(wrapper.classes()).to.include('nvw-scrollview--horizontal');
+    });
+
+    it(`Changing orientation property to vertical and it must be equal to vertical`, () => {
+      wrapper.setProps({ orientation: 'vertical' });
+      expect(wrapper.classes()).to.include('nvw-scrollview--vertical');
+      expect(wrapper.classes()).to.not.include('nvw-scrollview--horizontal');
+    });
+  });
+});


### PR DESCRIPTION
There are three TODO. 

TODOs
1. scrollBarIndicatorVisible -- Web browsers not supported.
2. Label prop of textWrap is leads to design problem. Web and mobile are different.(Image 2)
3. Scroll event will be update in tests.




**- Image 1**
![image](https://user-images.githubusercontent.com/8903053/44146759-db18d102-a099-11e8-88a2-2140636154ed.png)

**- Image 2**
![image](https://user-images.githubusercontent.com/8903053/44146809-0c1f10f4-a09a-11e8-9957-b2d86d58f260.png)