### PR TITLE
Fixes on Switcher(Switch) and Test

### DIFF
--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -1,15 +1,12 @@
 <template>
-    <label v-common-directive class="nvw-switch">
-        <input
-          class="nvw-switch__input"
-          ref="switch"
-          type="checkbox"
-          :checked="checked"
-          @change="checkedChange ? checkedChange($event) : null"
-          @click="updateValue()"
-        />
-        <span class="nvw-switch__slider" />
-    </label>
+  <input
+    v-common-directive
+    class="nvw-switch"
+    type="checkbox"
+    :checked="checked"
+    @change="$emit('checkedChange', $event)"
+    @click="updateValue"
+  />
 </template>
 
 <script>
@@ -26,11 +23,10 @@ export default {
       type: Boolean,
       default: false,
     },
-    checkedChange: Function,
   },
   methods: {
-    updateValue: function() {
-      this.$emit('input', this.$refs.switch.checked);
+    updateValue: function(event) {
+      this.$emit('input', event.target.checked);
     },
   },
   directives: {
@@ -38,72 +34,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.nvw-switch {
-  position: relative;
-  display: inline-block;
-  width: 90px;
-  height: 34px;
-
-  &__input {
-    display: none;
-  }
-
-  &__input:checked + &__slider {
-    background-color: #2ab934;
-  }
-
-  &__input:checked + &__slider:before {
-    -webkit-transform: translateX(26px);
-    -ms-transform: translateX(26px);
-    transform: translateX(55px);
-  }
-
-  &__input:checked + &__slider:after {
-    content: 'ON';
-  }
-
-  &__slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    background-color: #ca2222;
-    -webkit-transition: 0.5s;
-    transition: 0.4s;
-    border-radius: 34px;
-  }
-
-  &__slider:before {
-    position: absolute;
-    content: '';
-    height: 26px;
-    width: 26px;
-    left: 4px;
-    bottom: 4px;
-    background-color: white;
-    -webkit-transition: 0.4s;
-    transition: 0.4s;
-    border-radius: 50%;
-  }
-
-  &__input:focus + &__slider {
-    box-shadow: 0 0 1px #2196f3;
-  }
-
-  &__slider:after {
-    content: 'OFF';
-    color: white;
-    display: block;
-    position: absolute;
-    transform: translate(-50%, -50%);
-    top: 50%;
-    left: 50%;
-    font-size: 10px;
-    font-family: Verdana, sans-serif;
-  }
-}
-</style>

--- a/tests/unit/components/Switcher.spec.js
+++ b/tests/unit/components/Switcher.spec.js
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { mount } from '@vue/test-utils';
+import sinon from 'sinon';
+import { Switcher } from '../../../src/main';
+
+describe('Switcher', () => {
+  const checked = false;
+  const checkedChange = sinon.spy();
+  const clickHandler = sinon.spy(Switcher.methods, 'updateValue');
+  const wrapper = mount(Switcher, {
+    model: {
+      event: 'input',
+      prop: 'checked',
+    },
+    props: {
+      checked: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    propsData: {
+      checked,
+    },
+    listeners: {
+      checkedChange,
+    },
+  });
+
+  describe('the switcher component is an input component and its type is checkbox.', () => {
+    it('there is an input field.', () => {
+      expect(wrapper.contains('input')).to.equal(true);
+    });
+    it('the type of the component is checkbox', () => {
+      expect(wrapper.find('input').attributes('type').type).to.equal('checkbox');
+    });
+  });
+
+  describe('The wrapper component receives given props correctly.', () => {
+    it(`checked value of the input is equal to ${checked}`, () => {
+      expect(wrapper.vm.checked).to.equal(checked);
+    });
+
+    it('checkedChange event listener is passed to the component successfully.', () => {
+      expect(wrapper.vm.$listeners.checkedChange).to.not.equal(undefined);
+    });
+  });
+
+  describe('The wrapper component detects changes in the input field and also throw appropriate events.', () => {
+    it(`switcher component gets clicked, it detects the click behaviour and then, changes the value(${checked}) to ${!checked}.`, () => {
+      wrapper.trigger('click');
+      expect(clickHandler.called).to.equal(true);
+      expect(wrapper.find('input').element.checked).to.equal(true);
+    });
+    it('switcher component emits input and checkedChange events correctly.', () => {
+      expect(wrapper.emitted().input.length).to.equal(1);
+      expect(wrapper.emitted().input[0][0]).to.equal(true);
+      expect(wrapper.emitted().checkedChange.length).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
Testing, fixes on event handling of Switch and deleting the existing style of the component. The switch component is a basic checkbox now. 
![switchertestresult_29_08_2018](https://user-images.githubusercontent.com/19668362/44776884-cfc93100-ab81-11e8-9953-d92683a0d26b.JPG)
