### PR TITLE
Icon supports added

### DIFF
--- a/src/components/Label.vue
+++ b/src/components/Label.vue
@@ -1,9 +1,10 @@
 <template>
-  <div v-common-directive 
-   class="nvw-label" 
+  <span v-common-directive
+   class="nvw-label"
+   :class="fontClass"
    :style="{'white-space': textWrap ? 'normal' : 'nowrap'}">
-    {{text}}
-  </div>
+    {{textValue}}
+  </span>
 </template>
 
 <script>
@@ -21,11 +22,22 @@ export default {
   directives: {
     'common-directive': CommonDirective,
   },
+  computed: {
+    fontClass() {
+      if (this.text.includes(' | fonticon')) {
+        return this.text.replace(' | fonticon', '');
+      }
+    },
+    textValue() {
+      return this.text.includes(' | fonticon') ? '' : this.text;
+    },
+  },
 };
 </script>
 
 <style scoped lang='scss'>
 .nvw-label {
+  display: inline-block;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/plugins/dialog/index.js
+++ b/src/plugins/dialog/index.js
@@ -109,6 +109,10 @@ const DialogPlugin = {
         });
       });
     };
+
+    Vue.filter('fonticon', function(value) {
+      return value + ' | fonticon';
+    });
   },
 };
 export default DialogPlugin;

--- a/tests/unit/components/Label.spec.js
+++ b/tests/unit/components/Label.spec.js
@@ -23,10 +23,35 @@ describe('Label.vue', () => {
     expect(wrapper.props().textWrap).to.equal(textWrap);
   });
   it(`the type attribute which is equivalent of textWrap in Nativescript-vue is equal to: no-wrap.`, () => {
-    expect(wrapper.find('div').element.style.whiteSpace).to.equal('nowrap');
+    expect(wrapper.find(Label).element.style.whiteSpace).to.equal('nowrap');
   });
   it(`the type attribute which is equivalent of textWrap in Nativescript-vue is equal to: normal.`, () => {
     wrapper.setProps({ textWrap: true });
-    expect(wrapper.find('div').element.style.whiteSpace).to.equal('normal');
+    expect(wrapper.find(Label).element.style.whiteSpace).to.equal('normal');
+  });
+});
+
+describe('the component received given props correctly.', () => {
+  const text = 'bell | fonticon';
+  const wrapper = mount(Label, {
+    name: 'Label',
+    props: {
+      text: String,
+    },
+    propsData: {
+      text,
+    },
+  });
+  it(`Icon component given \`bell\` class`, () => {
+    expect(wrapper.find(Label).classes()).to.includes('bell');
+  });
+  it(`Icon components text should be empty`, () => {
+    expect(
+      wrapper
+        .find('span')
+        .text()
+        .replace(/\n/g, '')
+        .trim(),
+    ).to.equal('');
   });
 });

--- a/tests/unit/layouts/FlexboxLayout.spec.js
+++ b/tests/unit/layouts/FlexboxLayout.spec.js
@@ -123,7 +123,7 @@ describe('FlexboxLayout', () => {
 
       it('label component displays the given text prop(`here is the label`) correctly inside the layout.', () => {
         const labelWrappers = flexboxLayoutWrapper.findAll(Label).wrappers;
-        const label = labelWrappers[0].find('div');
+        const label = labelWrappers[0].find(Label);
         expect(label.element.textContent.trim()).to.equal('here is the label');
       });
     });

--- a/tests/unit/layouts/GridLayout.spec.js
+++ b/tests/unit/layouts/GridLayout.spec.js
@@ -96,13 +96,13 @@ describe('GridLayout', () => {
 
     it('label component displays the given text prop(`First`) correctly inside the layout.', () => {
       const labelWrappers = gridLayoutWrapper.findAll(Label).wrappers;
-      const label = labelWrappers[0].find('div');
+      const label = labelWrappers[0].find(Label);
       expect(label.element.textContent.trim()).to.equal('First');
     });
 
     it('label component displays the given text prop(`Second`) correctly inside the layout.', () => {
       const labelWrappers = gridLayoutWrapper.findAll(Label).wrappers;
-      const label = labelWrappers[1].find('div');
+      const label = labelWrappers[1].find(Label);
       expect(label.element.textContent.trim()).to.equal('Second');
     });
   });

--- a/tests/unit/layouts/WrapLayout.spec.js
+++ b/tests/unit/layouts/WrapLayout.spec.js
@@ -117,13 +117,13 @@ describe('WrapLayout', () => {
 
     it('label component displays the given text prop(`First`) correctly inside the layout.', () => {
       const labelWrappers = wrapLayoutWrapper.findAll(Label).wrappers;
-      const label = labelWrappers[0].find('div');
+      const label = labelWrappers[0].find(Label);
       expect(label.element.textContent.trim()).to.equal('First');
     });
 
     it('label component displays the given text prop(`Second`) correctly inside the layout.', () => {
       const labelWrappers = wrapLayoutWrapper.findAll(Label).wrappers;
-      const label = labelWrappers[1].find('div');
+      const label = labelWrappers[1].find(Label);
       expect(label.element.textContent.trim()).to.equal('Second');
     });
   });


### PR DESCRIPTION
Icon support added to Label component.

Using: <Label class="nuicon" :text="'bell' | fonticon" />
Vue.use(DialogPlugin) //in main.js
Note: fonticon filter must be defined. (fonticon is defined in DialogPlugin).

![image](https://user-images.githubusercontent.com/8903053/45636282-f2c77080-baaf-11e8-974a-01aae15df999.png)
